### PR TITLE
Filtering recommended articles for the selected item 

### DIFF
--- a/backend/imports/api/server/publications/newsArticles.js
+++ b/backend/imports/api/server/publications/newsArticles.js
@@ -1306,6 +1306,7 @@ Meteor.publish('furtherRecommendedNewsArticles', function furtherRecommendedNews
      */
     
     // Get list of specific recommendations for an item (can be for a specific user or generic recommendation)
+    // It also filters by experiment and user group
     const recListItem = RecommendationListsItem.find({
         articleId: cleanId,
         $or: [

--- a/backend/imports/api/server/publications/newsArticles.js
+++ b/backend/imports/api/server/publications/newsArticles.js
@@ -1291,6 +1291,9 @@ Meteor.publish('furtherRecommendedNewsArticles', function furtherRecommendedNews
     let initializing = true;
     const { userId } = this;
 
+    // getting the current user object
+    const user = Meteor.users.findOne({ _id: this.userId }, { fields: { participatesIn: 1, userGroup: 1 } });
+
     const cleanId = removeWeirdMinusSignsInFrontOfString(articleId);
 
     /**
@@ -1308,7 +1311,9 @@ Meteor.publish('furtherRecommendedNewsArticles', function furtherRecommendedNews
         $or: [
           { userId: userId }, // for a specific user
           { userId: "" }      // generic, for all users
-        ]
+        ],
+        participatesIn: user.participatesIn,
+        userGroup: user.userGroup
       }).fetch();
 
     // Select a subset of the entries limited to a certain amount, based on the probability of being selected


### PR DESCRIPTION
This proposed change is helpful for scenarios where recommendations are shown per item.

It introduces a filter that displays only recommendations relevant to the user's assigned experiment and group. This is particularly useful when handling generic recommendations — that is, recommendations not tied to a specific user (userId is empty). In such cases, the recommendations can still vary based on the user's group, allowing for personalised yet reusable recommendations across users within the same group.

This filter has no effect on user-specific recommendations (where userId is set), as those are already uniquely tailored.

This approach offers performance and scalability benefits. By reusing group-based recommendations rather than computing or storing unique ones for each user, we reduce redundancy and improve efficiency, mainly when recommendations are based on shared criteria like content similarity.

