### PR TITLE
migration from kadira:flow-router to ostrio:flow-router-extra

### DIFF
--- a/backend/.meteor/packages
+++ b/backend/.meteor/packages
@@ -14,10 +14,10 @@ standard-minifier-js@2.8.1    # JS minifier run for production modees5-shim@4.8.
 ecmascript@0.16.8              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.5.0            # Server-side component of the `meteor shell` command
 
-kadira:flow-router
 accounts-password@2.4.0
 alanning:roles
 meteortesting:mocha
 email@2.2.5
 session@1.2.1
 react-meteor-data@2.0.0
+ostrio:flow-router-extra

--- a/backend/.meteor/versions
+++ b/backend/.meteor/versions
@@ -30,7 +30,6 @@ hot-code-push@1.0.4
 http@1.4.3
 id-map@1.1.1
 inter-process-messaging@0.1.1
-kadira:flow-router@2.12.1
 lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.3.3
@@ -52,6 +51,7 @@ mongo-dev-server@1.1.0
 mongo-id@1.0.8
 npm-mongo@4.17.2
 ordered-dict@1.1.0
+ostrio:flow-router-extra@3.12.0
 promise@0.12.2
 random@1.2.1
 rate-limit@1.1.1

--- a/backend/imports/startup/client/router/config_routes.js
+++ b/backend/imports/startup/client/router/config_routes.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 
 
 // do not return anything before the subscription has finished loading.

--- a/backend/imports/startup/client/router/routes/general.js
+++ b/backend/imports/startup/client/router/routes/general.js
@@ -1,4 +1,4 @@
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import React from 'react';
 import { mount } from 'react-mounter';
 import PublicPages from '../../../../ui/PublicPages';

--- a/backend/imports/startup/client/router/routes/private.js
+++ b/backend/imports/startup/client/router/routes/private.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { mount } from 'react-mounter';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import React from 'react';
 import Root from '../../../../ui/Root';
 import { firstGrantedRoute, routeGranted } from '../utils_routes';

--- a/backend/imports/startup/client/router/routes/public.js
+++ b/backend/imports/startup/client/router/routes/public.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import { mount } from 'react-mounter';
 
 import { firstGrantedRoute } from '../utils_routes';

--- a/backend/imports/ui/components/articles/Preview.jsx
+++ b/backend/imports/ui/components/articles/Preview.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import { classNames } from '../../../lib/utils/utils';
 
 export default class Preview extends Component {

--- a/backend/imports/ui/components/experiments/ModalCreateExperiment.jsx
+++ b/backend/imports/ui/components/experiments/ModalCreateExperiment.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Meteor } from 'meteor/meteor';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import '@fortawesome/fontawesome-free/js/all';
 import ModalBody from '../../elements/modal/ModalBody';
 import ModalFoot from '../../elements/modal/ModalFoot';

--- a/backend/imports/ui/components/experiments/ModalEditExperiment.jsx
+++ b/backend/imports/ui/components/experiments/ModalEditExperiment.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Meteor } from 'meteor/meteor';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import '@fortawesome/fontawesome-free/js/all';
 import ModalBody from '../../elements/modal/ModalBody';
 import ModalFoot from '../../elements/modal/ModalFoot';

--- a/backend/imports/ui/components/surveys/ModalSurvey.jsx
+++ b/backend/imports/ui/components/surveys/ModalSurvey.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Meteor } from 'meteor/meteor';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import '@fortawesome/fontawesome-free/js/all';
 import ModalBody from '../../elements/modal/ModalBody';
 import ModalFoot from '../../elements/modal/ModalFoot';

--- a/backend/imports/ui/modules/articles/Article.jsx
+++ b/backend/imports/ui/modules/articles/Article.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import PropTypes from 'prop-types';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 
 import { Meteor } from 'meteor/meteor';
 import { NewsArticles } from '../../../api/articles';

--- a/backend/imports/ui/modules/surveys/Survey.jsx
+++ b/backend/imports/ui/modules/surveys/Survey.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Button from '../../elements/Button';
 import { useTheme } from '../../context/ThemeContext';
 import FaIcon from '../../elements/FaIcon';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 
 
 export default function Survey (props) {

--- a/backend/imports/ui/modules/surveys/SurveyEditPanel.jsx
+++ b/backend/imports/ui/modules/surveys/SurveyEditPanel.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
-import { FlowRouter } from 'meteor/kadira:flow-router';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import { Meteor } from 'meteor/meteor';
 
 import { Surveys } from '../../../api/surveys';

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -22,7 +22,8 @@ import StorageKeys from './components/utils/StorageKeys';
 // when running in Expo client, do not show yellow box for react-native-i18n linking warning
 console.ignoredYellowBox = ['react-native-i18n module is not correctly linked'];
 
-const SERVER = 'wss://your.domain/websocket';
+const SERVER = 'wss://aimdrrs.nl/websocket';
+// const SERVER = 'ws://ecaai-comp-prd1.ict.hva.nl:3008/websocket';
 // const SERVER = 'localhost';
 // const SERVER = 'ws://192.168.0.22:3008/websocket';
 // const SERVER = 'ws://192.168.43.24:3008/websocket';

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,16 +2,16 @@
   "expo": {
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
-    "name": "[APPLICATION-NAME]",
-    "slug": "[APPLICATION-NAME]",
-    "version": "X.Y.Z",
+    "name": "Nemo Informfully",
+    "slug": "Nemo Informfully",
+    "version": "1.0.0",
     "icon": "./assets/logo_1024.png",
     "platforms": [
       "ios",
       "android"
     ],
     "android": {
-      "package": "[BUNDLE-ID-ANDROID]]",
+      "package": "nl.nemokennislink.informfully",
       "versionCode": 28,
       "adaptiveIcon": {
         "foregroundImage": "./assets/logo_1024_android_adaptive_foreground.png",
@@ -20,7 +20,7 @@
       }
     },
     "ios": {
-      "bundleIdentifier": "[BUNDLE-ID-IOS]",
+      "bundleIdentifier": "nl.nemokennislink.informfully",
       "config": { "usesNonExemptEncryption": false }
     },
     "updates": {

--- a/frontend/components/screens/Article.js
+++ b/frontend/components/screens/Article.js
@@ -358,6 +358,27 @@ class InnerArticle extends React.Component {
                     // eslint-disable-next-line react/no-array-index-key
                     return <Text key={i} style={newsArticlesStyleGenerator().quote}>{text}</Text>;
                 }
+                if (type === 'image' && text) {
+                    return (
+                                <View key={i} style={{ marginVertical: 10, alignItems: 'center' }}>
+                                    <Image
+                                        style={{
+                                            width: fullWidth * 0.9,
+                                            height: (fullWidth * 0.9) * 0.56,
+                                            resizeMode: 'cover',
+                                            borderRadius: 6,
+                                        }}
+                                        source={{uri: text }}
+                                    />
+                                    {/* // in the future we could add a caption here */}
+                                    {/* {caption ? (
+                                        <Text style={[newsArticlesStyleGenerator().paragraph, { fontStyle: 'italic', marginTop: 5, textAlign: 'center' }]}>
+                                            {caption}
+                                        </Text>
+                                    ) : null} */}
+                                </View>
+                            );
+                }
             }
             return null;
         });

--- a/frontend/components/screens/Contact.js
+++ b/frontend/components/screens/Contact.js
@@ -41,7 +41,7 @@ class Contact extends React.Component {
 
                     </View>
 
-                    <View style={styles().clickableItems}>
+                    {/* <View style={styles().clickableItems}>
 
 
                         <View style={styles().itemSeparator} />
@@ -58,7 +58,7 @@ class Contact extends React.Component {
                         <View style={styles().itemSpace} />
 
 
-                    </View>
+                    </View> */}
 
 
                     <Text style={styles().addressText}>{this.props.addressTitle}</Text>
@@ -69,8 +69,8 @@ class Contact extends React.Component {
                     <Text style={styles().addressText}>{this.props.addressCountry}</Text>
                     <View style={styles().itemSpace} />
 
-                    <Text style={styles().addressText}>{this.props.phoneNumber}</Text>
-                    <View style={styles().itemSpace} />
+                    {/* <Text style={styles().addressText}>{this.props.phoneNumber}</Text> */}
+                    {/* <View style={styles().itemSpace} /> */}
                     <Text style={styles().addressText}>{this.props.feedbackEmail}</Text>
 
 
@@ -99,12 +99,12 @@ Contact.propTypes = {
 
 Contact.defaultProps = {
     feedbackEmail: 'placeholder@your.domain',
-    addressTitle: 'Name',
-    addressName: 'Details',
-    addressStreet: 'Street',
-    addressCity: 'City',
-    addressCountry: 'Country',
-    phoneNumber: '+98 76 654 32 10',
+    addressTitle: 'NEMO Science Museum',
+    addressName: 'Bezoekadres:',
+    addressStreet: 'Oosterdok 2',
+    addressCity: '1011 VX Amsterdam Amsterdam',
+    addressCountry: 'Nederland',
+    phoneNumber: '',
 };
 
 const styles = () => StyleSheet.create({

--- a/frontend/components/screens/Settings.js
+++ b/frontend/components/screens/Settings.js
@@ -280,7 +280,7 @@ class Settings extends React.Component {
 
                     <View style={styles().itemSpace} />
 
-                    <Collapse>
+                    {/* <Collapse>
                         <CollapseHeader>
                             <View style={styles().listItem}>
                                 <Text style={styles().listHeader}>{I18n.t('SETTINGS.APP_INFO')}</Text>
@@ -320,7 +320,7 @@ class Settings extends React.Component {
 
                         <View style={styles().itemSeparator} />
                         </CollapseBody>
-                    </Collapse>
+                    </Collapse> */}
 
                     <View style={styles().clickableItems}>
                         <View style={styles().itemSpace} />
@@ -333,12 +333,12 @@ class Settings extends React.Component {
                         </TouchableOpacity>
                         <View style={styles().itemSeparator} />
 
-                        <TouchableOpacity
+                        {/* <TouchableOpacity
                             style={styles().listItem}
                             onPress={() => { this.props.navigation.navigate('Tutorial'); }}
                         >
                             <Text style={styles().listItemText}>{I18n.t('SETTINGS.RETAKE_TUTORIAL')}</Text>
-                        </TouchableOpacity>
+                        </TouchableOpacity> */}
                         <View style={styles().itemSeparator} />
                         
                         <View style={styles().itemSpace} />

--- a/frontend/config/index.js
+++ b/frontend/config/index.js
@@ -13,4 +13,4 @@ export const HOMEPAGE_URL = 'https://your.domain/';
 // if you set the html, the html will be displayed instead of the url
 // export const PRIVACY_POLICY_HTML = '<h1>Datenschutzbestimmungen</h1>';
 
-export const DELETEACCOUNT_URL = 'https://your.domain/delete';
+export const DELETEACCOUNT_URL = 'https://www.nemokennislink.nl/toelichting-op-deelname-aan-ons-onderzoek';


### PR DESCRIPTION
The flow management of the backend UI is breaking. It happens when the app is compiled for production and the JS code is minified. I was able to isolate the problem, coming from the kadira:flow-router library. 

The following image was captured in the browser's inspector area right after clicking the login button.

![image](https://github.com/user-attachments/assets/42a99ff1-5a3e-4105-9a3b-b103b2f6d049)

This thread explains the problem in details: https://github.com/meteor/meteor/issues/11775#issuecomment-979341292

In summary:
- The issue was traced to a change in Meteor’s JavaScript minifier, specifically related to the Terser configuration
- This affected how dead code elimination worked during the minification step.
- kadira:flow-router used outdated JavaScript patterns (e.g., var declarations). Terser misinterpreted these, causing causing issues.

The Meteor team deprecated kadira:flow-router and recommended switching to the modernised fork: ostrio:flow-router-extra, which works fine with Terser's default settings.


